### PR TITLE
A work around for black screen on window start in macOS Mojave (10.14)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 #   Name/Organization <email address>
 
 juju <gliheng@foxmail.com>
+Boutglay Wael <btwael@gmail.com>

--- a/flutter-engine/src/lib.rs
+++ b/flutter-engine/src/lib.rs
@@ -71,6 +71,11 @@ extern fn present(data: *const c_void) -> bool {
     unsafe {
         let window: &mut glfw::Window = &mut *(data as *mut glfw::Window);
         window.swap_buffers();
+
+        // A work around for black screen on window start in macOS Mojave (10.14)
+        let pos = window.get_pos();
+        window.set_pos(pos.0 + 1, pos.1);
+        window.set_pos(pos.0, pos.1);
     }
     true
 }

--- a/flutter-engine/src/lib.rs
+++ b/flutter-engine/src/lib.rs
@@ -73,12 +73,14 @@ extern fn present(data: *const c_void) -> bool {
         window.swap_buffers();
 
         // A work around for black screen on window start in macOS Mojave (10.14)
-        static mut is_initially_visible: bool = false;
-        if !is_initially_visible {
-            let pos = window.get_pos();
-            window.set_pos(pos.0 + 1, pos.1);
-            window.set_pos(pos.0, pos.1);
-            is_initially_visible = true;
+        if cfg!(target_os = "macos") {
+            static mut is_initially_visible: bool = false;
+            if !is_initially_visible {
+                let pos = window.get_pos();
+                window.set_pos(pos.0 + 1, pos.1);
+                window.set_pos(pos.0, pos.1);
+                is_initially_visible = true;
+            }
         }
     }
     true

--- a/flutter-engine/src/lib.rs
+++ b/flutter-engine/src/lib.rs
@@ -73,9 +73,13 @@ extern fn present(data: *const c_void) -> bool {
         window.swap_buffers();
 
         // A work around for black screen on window start in macOS Mojave (10.14)
-        let pos = window.get_pos();
-        window.set_pos(pos.0 + 1, pos.1);
-        window.set_pos(pos.0, pos.1);
+        static mut is_initially_visible: bool = false;
+        if !is_initially_visible {
+            let pos = window.get_pos();
+            window.set_pos(pos.0 + 1, pos.1);
+            window.set_pos(pos.0, pos.1);
+            is_initially_visible = true;
+        }
     }
     true
 }


### PR DESCRIPTION
When running a `flutter-rs` application on macOS Mojave (10.14), a black screen is what we get initially until the window is moved or resized, this problem is reported at glfw/glfw#1334 and doesn't affect previous version of macOS.

This pull request contains a work around for this issue which is automatically moving (and moving back) the window with 1px. (the work around should not affect the code in other platforms) 