### PR TITLE
Determine target from environment

### DIFF
--- a/flutter-app-demo/rust/build.rs
+++ b/flutter-app-demo/rust/build.rs
@@ -26,6 +26,7 @@ fn main() {
     if let Ok(rx) = flutter_download::download_to(
         &version,
         &libs_dir,
+        flutter_download::default_target(),
     ) {
         // THis is /bin/internal/engine.version file in your flutter sdk
         for (total, done) in rx.iter() {
@@ -44,7 +45,7 @@ fn main() {
     #[cfg(target_os="macos")] {
         println!("cargo:rustc-link-search=framework={}", libs_dir.to_str().expect("libs_dir invalid"));
     }
-    
+
     #[cfg(target_os="windows")] {
         println!("cargo:rustc-link-search=native={}", libs_dir.to_str().expect("libs_dir invalid"));
 

--- a/flutter-app-demo/rust/build.rs
+++ b/flutter-app-demo/rust/build.rs
@@ -26,7 +26,6 @@ fn main() {
     if let Ok(rx) = flutter_download::download_to(
         &version,
         &libs_dir,
-        flutter_download::default_target(),
     ) {
         // THis is /bin/internal/engine.version file in your flutter sdk
         for (total, done) in rx.iter() {


### PR DESCRIPTION
As `flutter-download` is intended to be used in build scripts, the download URLs aren't correct when cross compiling. This PR uses the `TARGET` environment variable in `flutter-download` instead of configuration flags to determine which library to download. That way, even when the build script itself is compiled and run on Linux, the libraries for other platforms can be downloaded when cross compiling.