### PR TITLE
Allow key repeat

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 
 juju <gliheng@foxmail.com>
 Boutglay Wael <btwael@gmail.com>
+Sophie Tauchert <sophie@999eagle.moe>

--- a/flutter-engine/src/lib.rs
+++ b/flutter-engine/src/lib.rs
@@ -200,7 +200,7 @@ fn handle_event(window: &mut glfw::Window, event: glfw::WindowEvent) {
         glfw::WindowEvent::Key(Key::Escape, _, Action::Press, _) => {
             window.set_should_close(true)
         }
-        glfw::WindowEvent::Key(key, _, Action::Press, modifiers) => {
+        glfw::WindowEvent::Key(key, _, Action::Press, modifiers) | glfw::WindowEvent::Key(key, _, Action::Repeat, modifiers) => {
             match key {
                 Key::Enter => {
                     FlutterEngine::with_plugin(window.window_ptr(), "flutter/textinput", |p: &Box<TextInputPlugin>| {
@@ -457,13 +457,13 @@ impl FlutterEngineInner {
 
     fn add_system_plugins(&self) {
         let registry = &mut *self.registry.borrow_mut();
-        
+
         let plugin = TextInputPlugin::new();
         registry.add_plugin(Box::new(plugin));
 
         let plugin = PlatformPlugin::new();
         registry.add_plugin(Box::new(plugin));
-        
+
         let plugin = DialogPlugin::new();
         registry.add_plugin(Box::new(plugin));
 


### PR DESCRIPTION
This PR adds key repeat, that is key input keeps on being sent to flutter when a key is held down. Mostly useful for Backspace and Arrow keys.
I've also added myself to `AUTHORS` per #16.