### PR TITLE
Add custom handler function for glfw window events

### DIFF
--- a/flutter-engine/src/lib.rs
+++ b/flutter-engine/src/lib.rs
@@ -68,6 +68,8 @@ pub struct FlutterEngineArgs {
     pub bg_color: (u8, u8, u8),
     pub window_mode: WindowMode,
     pub command_line_args: Option<Vec<String>>,
+    /// A custom handler for glfw window events. If not `None`, this handler will be called for every
+    /// window event and the default handler will only be called if `true` is returned.
     pub window_event_handler:Option<Box<fn(&mut glfw::Window, glfw::WindowEvent) -> bool>>,
 }
 

--- a/flutter-engine/src/lib.rs
+++ b/flutter-engine/src/lib.rs
@@ -70,7 +70,7 @@ pub struct FlutterEngineArgs {
     pub command_line_args: Option<Vec<String>>,
     /// A custom handler for glfw window events. If not `None`, this handler will be called for every
     /// window event and the default handler will only be called if `true` is returned.
-    pub window_event_handler:Option<Box<fn(&mut glfw::Window, glfw::WindowEvent) -> bool>>,
+    pub window_event_handler:Option<Box<fn(&FlutterEngineInner, &mut glfw::Window, glfw::WindowEvent) -> bool>>,
 }
 
 impl Default for FlutterEngineArgs {
@@ -497,7 +497,7 @@ impl FlutterEngineInner {
 
                 for (_, event) in glfw::flush_messages(&events) {
                     let call_default_handler = match &self.args.window_event_handler {
-                        Some(handler) => handler(window, event.clone()),
+                        Some(handler) => handler(&self, window, event.clone()),
                         None => true,
                     };
                     if call_default_handler {

--- a/flutter-engine/src/plugins/mod.rs
+++ b/flutter-engine/src/plugins/mod.rs
@@ -52,8 +52,13 @@ impl PluginRegistry {
             warn!("No plugin registered to handle messages from channel: {}", &msg.channel);
         }
     }
+
     pub fn get_plugin(&self, channel: &str) -> Option<&Box<dyn Plugin>> {
         self.map.get(channel)
+    }
+
+    pub fn get_plugin_mut(&mut self, channel: &str) -> Option<&mut Box<dyn Plugin>> {
+        self.map.get_mut(channel)
     }
 }
 


### PR DESCRIPTION
This PR adds the possibility to handle glfw window events in the calling application. The custom handler may also cancel the default handling in `flutter-rs` for any window event by returning false from the custom handler.