### PR TITLE
Use correct modifier key for text navigation on macOS

### DIFF
--- a/flutter-engine/src/plugins/textinput.rs
+++ b/flutter-engine/src/plugins/textinput.rs
@@ -173,7 +173,7 @@ impl TextInputPlugin {
             } else {
                 lo
             };
-            let next_pos = if modifiers.contains(Modifiers::Control) {
+            let next_pos = if cfg!(target_os = "macos") && modifiers.contains(Modifiers::Super) || modifiers.contains(Modifiers::Control) {
                 self.get_next_word_boundary(s, current_pos, false)
             } else {
                 (current_pos - 1).max(0)
@@ -198,7 +198,7 @@ impl TextInputPlugin {
             } else {
                 hi
             };
-            let next_pos = if modifiers.contains(Modifiers::Control) {
+            let next_pos = if cfg!(target_os = "macos") && modifiers.contains(Modifiers::Super) || modifiers.contains(Modifiers::Control) {
                 self.get_next_word_boundary(s, current_pos, true)
             } else {
                 (current_pos + 1).min(s.text.count() as i64)

--- a/flutter-engine/src/plugins/textinput.rs
+++ b/flutter-engine/src/plugins/textinput.rs
@@ -173,7 +173,7 @@ impl TextInputPlugin {
             } else {
                 lo
             };
-            let next_pos = if cfg!(target_os = "macos") && modifiers.contains(Modifiers::Super) || modifiers.contains(Modifiers::Control) {
+            let next_pos = if cfg!(target_os = "macos") && modifiers.contains(Modifiers::Alt) || modifiers.contains(Modifiers::Control) {
                 self.get_next_word_boundary(s, current_pos, false)
             } else {
                 (current_pos - 1).max(0)
@@ -198,7 +198,7 @@ impl TextInputPlugin {
             } else {
                 hi
             };
-            let next_pos = if cfg!(target_os = "macos") && modifiers.contains(Modifiers::Super) || modifiers.contains(Modifiers::Control) {
+            let next_pos = if cfg!(target_os = "macos") && modifiers.contains(Modifiers::Alt) || modifiers.contains(Modifiers::Control) {
                 self.get_next_word_boundary(s, current_pos, true)
             } else {
                 (current_pos + 1).min(s.text.count() as i64)


### PR DESCRIPTION
This PR enables using Option+Left and Option+Right on macOS to move the cursor one word left/right.