### PR TITLE
Use content scale instead of calculating DPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ version = "0.2.1"
 dependencies = [
  "flutter-engine-sys 0.1.0",
  "gl 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glfw 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glfw 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -474,12 +474,12 @@ dependencies = [
 
 [[package]]
 name = "glfw"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glfw-sys 3.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glfw-sys 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "glfw-sys"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cmake 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1586,8 +1586,8 @@ dependencies = [
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum gl 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7d8c8e25e8ed44d4813809205090162723a866fb4be3a9d8bb983c9a0bf98f1"
 "checksum gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0ffaf173cf76c73a73e080366bf556b4776ece104b06961766ff11449f38604"
-"checksum glfw 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)" = "59fac8134a7f8a601444b20713c7285e55ebdc59226b5117bb1c458705944dbf"
-"checksum glfw-sys 3.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f72bb86276679c5370276224546eef2dce99b23da2f364fd8b097c79db310b39"
+"checksum glfw 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b83f216b28baf62a32501473fa2334bdc9bcf679c2c01c1a975ae6686709f"
+"checksum glfw-sys 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f18d2cf180dd18d06142b26758d32aeb6c71ba0a37c7f3ddafee22b8a3247cd3"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"

--- a/flutter-engine/Cargo.toml
+++ b/flutter-engine/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 flutter-engine-sys = { path = "../flutter-engine-sys" }
-glfw = "^0.27"
+glfw = "^0.28"
 gl = "0.11.0"
 libc = "0.2.44"
 serde = { version = "^1.0", features = ["derive"] }

--- a/flutter-engine/src/desktop_window_state.rs
+++ b/flutter-engine/src/desktop_window_state.rs
@@ -5,9 +5,8 @@ use crate::{
 
 use std::sync::{mpsc::Receiver, Arc};
 
-use log::info;
+use log::{debug, info};
 
-const DP_PER_INCH: f64 = 160.0;
 const SCROLL_SPEED: f64 = 20.0;
 #[cfg(not(target_os = "macos"))]
 const BY_WORD_MODIFIER_KEY: glfw::Modifiers = glfw::Modifiers::Control;
@@ -22,7 +21,6 @@ const FUNCTION_MODIFIER_KEY: glfw::Modifiers = glfw::Modifiers::Super;
 pub struct DesktopWindowState {
     pub runtime_data: Arc<RuntimeData>,
     pointer_currently_added: bool,
-    monitor_screen_coordinates_per_inch: f64,
     window_pixels_per_screen_coordinate: f64,
     pub plugin_registrar: PluginRegistrar,
 }
@@ -51,41 +49,29 @@ impl DesktopWindowState {
             window_event_receiver,
             engine: Arc::new(engine),
         });
-        let monitor_screen_coordinates_per_inch =
-            Self::get_screen_coordinates_per_inch(&mut runtime_data.window().glfw);
         Self {
             pointer_currently_added: false,
-            monitor_screen_coordinates_per_inch,
             window_pixels_per_screen_coordinate: 0.0,
             plugin_registrar: PluginRegistrar::new(Arc::downgrade(&runtime_data)),
             runtime_data,
         }
     }
 
-    pub fn send_framebuffer_size_change(&mut self, framebuffer_size: (i32, i32)) {
-        let window_size = self.runtime_data.window().get_size();
+    pub fn send_scale_or_size_change(&mut self) {
+        let window = self.runtime_data.window();
+        let window_size = window.get_size();
+        let framebuffer_size = window.get_framebuffer_size();
+        let scale = window.get_content_scale();
         self.window_pixels_per_screen_coordinate = framebuffer_size.0 as f64 / window_size.0 as f64;
-        let dpi =
-            self.window_pixels_per_screen_coordinate * self.monitor_screen_coordinates_per_inch;
-        let pixel_ratio = (dpi / DP_PER_INCH).max(1.0);
+        debug!(
+            "Setting framebuffer size to {:?}, scale to {}",
+            framebuffer_size, scale.0
+        );
         self.runtime_data.engine.send_window_metrics_event(
             framebuffer_size.0,
             framebuffer_size.1,
-            pixel_ratio,
+            scale.0 as f64,
         );
-    }
-
-    fn get_screen_coordinates_per_inch(glfw: &mut glfw::Glfw) -> f64 {
-        glfw.with_primary_monitor(|glfw, monitor| match monitor {
-            None => DP_PER_INCH,
-            Some(monitor) => match monitor.get_video_mode() {
-                None => DP_PER_INCH,
-                Some(video_mode) => {
-                    let (width, _) = monitor.get_physical_size();
-                    video_mode.width as f64 / (width as f64 / 25.4)
-                }
-            },
-        })
     }
 
     fn send_pointer_event(
@@ -198,8 +184,11 @@ impl DesktopWindowState {
                     -scroll_delta_y * SCROLL_SPEED,
                 );
             }
-            glfw::WindowEvent::FramebufferSize(width, height) => {
-                self.send_framebuffer_size_change((width, height));
+            glfw::WindowEvent::FramebufferSize(_, _) => {
+                self.send_scale_or_size_change();
+            }
+            glfw::WindowEvent::ContentScale(_, _) => {
+                self.send_scale_or_size_change();
             }
             glfw::WindowEvent::Char(char) => {
                 self.plugin_registrar

--- a/flutter-engine/src/lib.rs
+++ b/flutter-engine/src/lib.rs
@@ -117,9 +117,8 @@ impl FlutterDesktop {
             DesktopUserData::WindowState(DesktopWindowState::new(window_ref, receiver, engine));
 
         if let DesktopUserData::WindowState(window_state) = &mut self.user_data {
-            let framebuffer_size = window_state.runtime_data.window().get_framebuffer_size();
             // send initial size callback to engine
-            window_state.send_framebuffer_size_change(framebuffer_size);
+            window_state.send_scale_or_size_change();
 
             window_state.plugin_registrar.add_system_plugins();
 
@@ -133,6 +132,7 @@ impl FlutterDesktop {
             window.set_mouse_button_polling(true);
             window.set_scroll_polling(true);
             window.set_size_polling(true);
+            window.set_content_scale_polling(true);
         }
 
         Ok(())


### PR DESCRIPTION
This PR uses `window.get_content_scale()` from `glfw-rs` 0.28 / `glfw` 3.3.0 to set the scale for flutter instead of manually calculating the DPI.