### PR TITLE
Fix threading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,11 +259,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.6.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-epoch 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -273,18 +273,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-utils"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -400,7 +409,7 @@ dependencies = [
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "stream-cancel 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinyfiledialogs 3.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winres 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -425,6 +434,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -434,6 +444,11 @@ dependencies = [
  "bindgen 0.42.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "flutter-download 0.1.0",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -1225,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.1.13"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1233,14 +1248,16 @@ dependencies = [
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-current-thread 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-fs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1257,29 +1274,30 @@ dependencies = [
 
 [[package]]
 name = "tokio-current-thread"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-executor"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-fs"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1297,7 +1315,7 @@ name = "tokio-reactor"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1305,8 +1323,17 @@ dependencies = [
  "num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-sync"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1324,16 +1351,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-threadpool"
-version = "0.1.9"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1341,10 +1370,18 @@ name = "tokio-timer"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-trace-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1569,9 +1606,10 @@ dependencies = [
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e91d5240c6975ef33aeb5f148f35275c25eda8e8a5f95abe421978b05b8bf192"
-"checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
+"checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f10a4f8f409aaac4b16a5474fb233624238fcdeefb9ba50d5ea059aab63ba31c"
-"checksum crossbeam-utils 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "41ee4864f4797060e52044376f7d107429ce1fb43460021b126424b7180ee21a"
+"checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
+"checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum curl 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "c7c9d851c825e0c033979d4516c9173bc19a78a96eb4d6ae51d4045440eafa16"
 "checksum curl-sys 0.4.15 (registry+https://github.com/rust-lang/crates.io-index)" = "721c204978be2143fab0a84b708c49d79d1f6100b8785610f456043a90708870"
 "checksum dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a"
@@ -1581,6 +1619,7 @@ dependencies = [
 "checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "29d26fa0f4d433d1956746e66ec10d6bf4d6c8b93cd39965cceea7f7cc78c7dd"
 "checksum flate2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2291c165c8e703ee54ef3055ad6188e3d51108e2ded18e9f2476e774fc5ad3d4"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
@@ -1677,16 +1716,18 @@ dependencies = [
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "847da467bf0db05882a9e2375934a8a55cffdc9db0d128af1518200260ba1f6c"
 "checksum tinyfiledialogs 3.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d79833ca2c493c726ea6a7b651ba0ff8a790add5156cd11bf3743f346005c0c8"
-"checksum tokio 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "a7817d4c98cc5be21360b3b37d6036fe9b7aefa5b7a201b7b16ff33423822f7d"
+"checksum tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "cec6c34409089be085de9403ba2010b80e36938c9ca992c4f67f407bb13db0b1"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
-"checksum tokio-current-thread 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "331c8acc267855ec06eb0c94618dcbbfea45bed2d20b77252940095273fb58f6"
-"checksum tokio-executor 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c117b6cf86bb730aab4834f10df96e4dd586eff2c3c27d3781348da49e255bde"
-"checksum tokio-fs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "60ae25f6b17d25116d2cba342083abe5255d3c2c79cb21ea11aa049c53bf7c75"
+"checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
+"checksum tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "83ea44c6c0773cc034771693711c35c677b4b5a4b21b9e7071704c54de7d555e"
+"checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 "checksum tokio-io 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "7392fe0a70d5ce0c882c4778116c519bd5dbaa8a7c3ae3d04578b3afafdcda21"
 "checksum tokio-reactor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "502b625acb4ee13cbb3b90b8ca80e0addd263ddacf6931666ef751e610b07fb5"
+"checksum tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5b2f843ffdf8d6e1f90bddd48da43f99ab071660cd92b7ec560ef3cdfd7a409a"
 "checksum tokio-tcp 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ad235e9dadd126b2d47f6736f65aa1fdcd6420e66ca63f44177bc78df89f912"
-"checksum tokio-threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "56c5556262383032878afad66943926a1d1f0967f17e94bd7764ceceb3b70e7f"
+"checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
 "checksum tokio-timer 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "4f37f0111d76cc5da132fe9bc0590b9b9cfd079bc7e75ac3846278430a299ff8"
+"checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
 "checksum tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92"
 "checksum tokio-uds 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "99ce87382f6c1a24b513a72c048b2c8efe66cb5161c9061d00bee510f08dc168"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"

--- a/flutter-app-demo/rust/Cargo.toml
+++ b/flutter-app-demo/rust/Cargo.toml
@@ -11,10 +11,10 @@ identifier = "one.juju.flutter-app" # This is only used on mac
 
 [dependencies]
 log = "0.4.6"
-tokio = "0.1.13"
-futures = "0.1.25"
-tokio-timer = "0.2.8"
-stream-cancel = "0.4.4"
+tokio = "^0.1"
+futures = "^0.1"
+tokio-timer = "^0.2"
+stream-cancel = "^0.4"
 tinyfiledialogs = "3.3.5"
 flutter-engine = { path = "../../flutter-engine" }
 fern = { version = "^0.5", features = ["colored"] }

--- a/flutter-app-demo/rust/src/dialog.rs
+++ b/flutter-app-demo/rust/src/dialog.rs
@@ -7,13 +7,15 @@ const PLUGIN_NAME: &str = module_path!();
 const CHANNEL_NAME: &str = "flutter-rs/dialog";
 
 pub struct DialogPlugin {
-    channel: Weak<JsonMethodChannel>,
+    handler: Arc<RwLock<Handler>>,
 }
+
+struct Handler;
 
 impl DialogPlugin {
     pub fn new() -> Self {
         DialogPlugin {
-            channel: Weak::new(),
+            handler: Arc::new(RwLock::new(Handler)),
         }
     }
 }
@@ -23,125 +25,62 @@ impl Plugin for DialogPlugin {
         PLUGIN_NAME
     }
 
-    fn init_channels(&mut self, plugin: Weak<RwLock<Self>>, registrar: &mut ChannelRegistrar) {
-        self.channel = registrar.register_channel(JsonMethodChannel::new(CHANNEL_NAME, plugin));
+    fn init_channels(&mut self, registrar: &mut ChannelRegistrar) {
+        let method_handler = Arc::downgrade(&self.handler);
+        registrar.register_channel(JsonMethodChannel::new(CHANNEL_NAME, method_handler));
     }
 }
 
-impl MethodCallHandler for DialogPlugin {
-    fn handle_async(&self, _call: &MethodCall) -> bool {
-        // all calls here should be handled async
-        true
-    }
-
+impl MethodCallHandler for Handler {
     fn on_method_call(
         &mut self,
-        _channel: &str,
-        _call: MethodCall,
-        _window: &mut Window,
-    ) -> Result<Value, MethodCallError> {
-        // this can't happen as all calls are handled async
-        Err(MethodCallError::UnspecifiedError)
-    }
-
-    fn on_async_method_call(
-        &mut self,
-        _: &str,
         call: MethodCall,
-        _: &mut Window,
-        mut response_handle: Option<PlatformMessageResponseHandle>,
-    ) {
+        _: RuntimeData,
+    ) -> Result<Value, MethodCallError> {
         match call.method.as_str() {
             "open_file_dialog" => {
-                let channel = self.channel.clone();
-                let mut response_handle = response_handle.take();
-                std::thread::spawn(move || {
-                    let params = from_value::<OpenFileDialogParams>(&call.args);
-                    if params.is_err() {
-                        let channel = channel.upgrade().unwrap();
-                        channel.send_method_call_response(
-                            &mut response_handle,
-                            MethodCallResult::Err {
-                                code: "1002".to_owned(), // TODO: put errors together
-                                message: "Params error".to_owned(),
-                                details: Value::Null,
-                            },
-                        );
-                        return;
-                    }
-                    let params = params.unwrap();
-                    let OpenFileDialogParams {
-                        title,
-                        path,
-                        filter,
-                    } = params;
+                let params = from_value::<OpenFileDialogParams>(&call.args)?;
+                let OpenFileDialogParams {
+                    title,
+                    path,
+                    filter,
+                } = params;
 
-                    // Oh, these borrow stuff sux
-                    let filter2 = filter.as_ref().map(|(p, n)| {
-                        let p: Vec<&str> = p.iter().map(String::as_str).collect();
-                        (p, n)
-                    });
-                    let path = tinyfiledialogs::open_file_dialog(
-                        title.as_ref().unwrap_or(&String::from("")),
-                        path.as_ref().unwrap_or(&String::from("")),
-                        filter2.as_ref().map(|(p, n)| (p.as_slice(), n.as_str())),
-                    );
-
-                    let s = match &path {
-                        Some(p) => p,
-                        None => "",
-                    };
-                    let channel = channel.upgrade().unwrap();
-                    channel.send_method_call_response(
-                        &mut response_handle,
-                        MethodCallResult::Ok(json_value!(s)),
-                    );
+                // Oh, these borrow stuff sux
+                let filter2 = filter.as_ref().map(|(p, n)| {
+                    let p: Vec<&str> = p.iter().map(String::as_str).collect();
+                    (p, n)
                 });
+                let path = tinyfiledialogs::open_file_dialog(
+                    title.as_ref().unwrap_or(&String::from("")),
+                    path.as_ref().unwrap_or(&String::from("")),
+                    filter2.as_ref().map(|(p, n)| (p.as_slice(), n.as_str())),
+                );
+
+                let s = match &path {
+                    Some(p) => p,
+                    None => "",
+                };
+                Ok(json_value!(s))
             }
             "message_box_ok" => {
-                let channel = self.channel.clone();
-                let mut response_handle = response_handle.take();
-                std::thread::spawn(move || {
-                    let params = from_value::<MessageBoxOkParams>(&call.args);
-                    if params.is_err() {
-                        let channel = channel.upgrade().unwrap();
-                        channel.send_method_call_response(
-                            &mut response_handle,
-                            MethodCallResult::Err {
-                                code: "1002".to_owned(), // TODO: put errors together
-                                message: "Params error".to_owned(),
-                                details: Value::Null,
-                            },
-                        );
-                        return;
-                    }
-                    let params = params.unwrap();
-                    let MessageBoxOkParams {
-                        title,
-                        message,
-                        icon,
-                    } = params;
+                let params = from_value::<MessageBoxOkParams>(&call.args)?;
+                let MessageBoxOkParams {
+                    title,
+                    message,
+                    icon,
+                } = params;
 
-                    let icon = match icon.unwrap_or(MessageBoxIcon::Info) {
-                        MessageBoxIcon::Info => tinyfiledialogs::MessageBoxIcon::Info,
-                        MessageBoxIcon::Error => tinyfiledialogs::MessageBoxIcon::Error,
-                        MessageBoxIcon::Question => tinyfiledialogs::MessageBoxIcon::Question,
-                        MessageBoxIcon::Warning => tinyfiledialogs::MessageBoxIcon::Warning,
-                    };
-                    tinyfiledialogs::message_box_ok(title.as_str(), message.as_str(), icon);
-
-                    let channel = channel.upgrade().unwrap();
-                    channel.send_method_call_response(
-                        &mut response_handle,
-                        MethodCallResult::Ok(Value::Null),
-                    );
-                });
+                let icon = match icon.unwrap_or(MessageBoxIcon::Info) {
+                    MessageBoxIcon::Info => tinyfiledialogs::MessageBoxIcon::Info,
+                    MessageBoxIcon::Error => tinyfiledialogs::MessageBoxIcon::Error,
+                    MessageBoxIcon::Question => tinyfiledialogs::MessageBoxIcon::Question,
+                    MessageBoxIcon::Warning => tinyfiledialogs::MessageBoxIcon::Warning,
+                };
+                tinyfiledialogs::message_box_ok(title.as_str(), message.as_str(), icon);
+                Ok(Value::Null)
             }
-            _ => self
-                .channel
-                .upgrade()
-                .unwrap()
-                .send_method_call_response(&mut response_handle, MethodCallResult::NotImplemented),
+            _ => Err(MethodCallError::NotImplemented),
         }
     }
 }

--- a/flutter-app-demo/rust/src/main.rs
+++ b/flutter-app-demo/rust/src/main.rs
@@ -10,7 +10,6 @@ use std::{env, path::PathBuf};
 
 use fern::colors::{Color, ColoredLevelConfig};
 use log::info;
-use tokio::{prelude::*, runtime::Runtime};
 
 #[cfg(target_os = "macos")]
 use core_foundation::bundle;
@@ -78,7 +77,6 @@ fn main() {
     };
 
     let mut engine = flutter_engine::init().unwrap();
-    let rt = Runtime::new().unwrap();
     engine
         .create_window(
             1800,
@@ -94,9 +92,8 @@ fn main() {
             .plugin_registrar
             .add_plugin(calc_channel::CalcPlugin::new())
             .add_plugin(dialog::DialogPlugin::new())
-            .add_plugin(msg_stream_channel::MsgStreamPlugin::new(rt.executor()))
+            .add_plugin(msg_stream_channel::MsgStreamPlugin::new())
             .add_plugin(window::WindowPlugin::new());
     });
     engine.run_window_loop(None);
-    rt.shutdown_now().wait().unwrap();
 }

--- a/flutter-engine/Cargo.toml
+++ b/flutter-engine/Cargo.toml
@@ -17,3 +17,4 @@ libc = "0.2.44"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 log = "^0.4"
+tokio = "^0.1.19"

--- a/flutter-engine/src/channel.rs
+++ b/flutter-engine/src/channel.rs
@@ -176,6 +176,10 @@ pub trait MethodCallHandler {
 }
 
 pub trait EventHandler {
-    fn on_listen(&mut self, args: Value) -> Result<Value, MethodCallError>;
-    fn on_cancel(&mut self) -> Result<Value, MethodCallError>;
+    fn on_listen(
+        &mut self,
+        args: Value,
+        runtime_data: RuntimeData,
+    ) -> Result<Value, MethodCallError>;
+    fn on_cancel(&mut self, runtime_data: RuntimeData) -> Result<Value, MethodCallError>;
 }

--- a/flutter-engine/src/channel/event_channel.rs
+++ b/flutter-engine/src/channel/event_channel.rs
@@ -3,17 +3,15 @@ use std::sync::{Arc, RwLock, Weak};
 use crate::{
     channel::{Channel, EventHandler, MethodCallHandler},
     codec::{standard_codec::CODEC, MethodCall, MethodCodec, Value},
-    desktop_window_state::RuntimeData,
+    desktop_window_state::{InitData, RuntimeData},
     error::MethodCallError,
-    ffi::FlutterEngine,
-    Window,
 };
 
 use log::error;
 
 pub struct EventChannel {
     name: String,
-    engine: Weak<FlutterEngine>,
+    init_data: Weak<InitData>,
     method_handler: Arc<RwLock<MethodCallHandler>>,
     plugin_name: Option<&'static str>,
 }
@@ -26,7 +24,7 @@ impl EventChannel {
     pub fn new(name: &str, handler: Weak<RwLock<EventHandler>>) -> Self {
         Self {
             name: name.to_owned(),
-            engine: Weak::new(),
+            init_data: Weak::new(),
             method_handler: Arc::new(RwLock::new(EventChannelMethodCallHandler::new(handler))),
             plugin_name: None,
         }
@@ -38,17 +36,15 @@ impl Channel for EventChannel {
         &self.name
     }
 
-    fn engine(&self) -> Option<Arc<FlutterEngine>> {
-        self.engine.upgrade()
+    fn init_data(&self) -> Option<Arc<InitData>> {
+        self.init_data.upgrade()
     }
 
-    fn init(&mut self, runtime_data: Weak<RuntimeData>, plugin_name: &'static str) {
-        if self.engine.upgrade().is_some() {
+    fn init(&mut self, init_data: Weak<InitData>, plugin_name: &'static str) {
+        if self.init_data.upgrade().is_some() {
             error!("Channel {} was already initialized", self.name);
         }
-        if let Some(runtime_data) = runtime_data.upgrade() {
-            self.engine = Arc::downgrade(&runtime_data.engine);
-        }
+        self.init_data = init_data;
         self.plugin_name.replace(plugin_name);
     }
 
@@ -78,7 +74,7 @@ impl MethodCallHandler for EventChannelMethodCallHandler {
         &mut self,
         channel: &str,
         call: MethodCall,
-        _: &mut Window,
+        _: Arc<RuntimeData>,
     ) -> Result<Value, MethodCallError> {
         if let Some(handler) = self.event_handler.upgrade() {
             let mut handler = handler.write().unwrap();

--- a/flutter-engine/src/channel/event_channel.rs
+++ b/flutter-engine/src/channel/event_channel.rs
@@ -14,16 +14,16 @@ use log::error;
 pub struct EventChannel {
     name: String,
     engine: Weak<FlutterEngine>,
-    method_handler: Arc<RwLock<MethodCallHandler + Send + Sync>>,
+    method_handler: Arc<RwLock<MethodCallHandler>>,
     plugin_name: Option<&'static str>,
 }
 
 struct EventChannelMethodCallHandler {
-    event_handler: Weak<RwLock<EventHandler + Send + Sync>>,
+    event_handler: Weak<RwLock<EventHandler>>,
 }
 
 impl EventChannel {
-    pub fn new(name: &str, handler: Weak<RwLock<EventHandler + Send + Sync>>) -> Self {
+    pub fn new(name: &str, handler: Weak<RwLock<EventHandler>>) -> Self {
         Self {
             name: name.to_owned(),
             engine: Weak::new(),
@@ -52,7 +52,7 @@ impl Channel for EventChannel {
         self.plugin_name.replace(plugin_name);
     }
 
-    fn method_handler(&self) -> Option<Arc<RwLock<MethodCallHandler + Send + Sync>>> {
+    fn method_handler(&self) -> Option<Arc<RwLock<MethodCallHandler>>> {
         Some(Arc::clone(&self.method_handler))
     }
 
@@ -66,7 +66,7 @@ impl Channel for EventChannel {
 }
 
 impl EventChannelMethodCallHandler {
-    pub fn new(handler: Weak<RwLock<EventHandler + Send + Sync>>) -> Self {
+    pub fn new(handler: Weak<RwLock<EventHandler>>) -> Self {
         Self {
             event_handler: handler,
         }

--- a/flutter-engine/src/channel/event_channel.rs
+++ b/flutter-engine/src/channel/event_channel.rs
@@ -73,13 +73,13 @@ impl MethodCallHandler for EventChannelMethodCallHandler {
     fn on_method_call(
         &mut self,
         call: MethodCall,
-        _: RuntimeData,
+        runtime_data: RuntimeData,
     ) -> Result<Value, MethodCallError> {
         if let Some(handler) = self.event_handler.upgrade() {
             let mut handler = handler.write().unwrap();
             match call.method.as_str() {
-                "listen" => handler.on_listen(call.args),
-                "cancel" => handler.on_cancel(),
+                "listen" => handler.on_listen(call.args, runtime_data),
+                "cancel" => handler.on_cancel(runtime_data),
                 _ => Err(MethodCallError::NotImplemented),
             }
         } else {

--- a/flutter-engine/src/channel/json_method_channel.rs
+++ b/flutter-engine/src/channel/json_method_channel.rs
@@ -9,29 +9,32 @@ use crate::{
 use log::error;
 
 pub struct JsonMethodChannel {
-    name: String,
+    name: &'static str,
     init_data: Weak<InitData>,
-    method_handler: Weak<RwLock<MethodCallHandler>>,
+    method_handler: Weak<RwLock<MethodCallHandler + Send + Sync>>,
     plugin_name: Option<&'static str>,
 }
 
 impl JsonMethodChannel {
-    pub fn new(name: &str, method_handler: Weak<RwLock<MethodCallHandler>>) -> Self {
+    pub fn new(
+        name: &'static str,
+        method_handler: Weak<RwLock<MethodCallHandler + Send + Sync>>,
+    ) -> Self {
         Self {
-            name: name.to_owned(),
+            name,
             init_data: Weak::new(),
             method_handler,
             plugin_name: None,
         }
     }
 
-    pub fn set_handler(&mut self, method_handler: Weak<RwLock<MethodCallHandler>>) {
+    pub fn set_handler(&mut self, method_handler: Weak<RwLock<MethodCallHandler + Send + Sync>>) {
         self.method_handler = method_handler;
     }
 }
 
 impl Channel for JsonMethodChannel {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         &self.name
     }
 
@@ -47,7 +50,7 @@ impl Channel for JsonMethodChannel {
         self.plugin_name.replace(plugin_name);
     }
 
-    fn method_handler(&self) -> Option<Arc<RwLock<MethodCallHandler>>> {
+    fn method_handler(&self) -> Option<Arc<RwLock<MethodCallHandler + Send + Sync>>> {
         self.method_handler.upgrade()
     }
 

--- a/flutter-engine/src/channel/json_method_channel.rs
+++ b/flutter-engine/src/channel/json_method_channel.rs
@@ -3,15 +3,14 @@ use std::sync::{Arc, RwLock, Weak};
 use crate::{
     channel::{Channel, MethodCallHandler},
     codec::{json_codec::CODEC, MethodCodec},
-    desktop_window_state::RuntimeData,
-    ffi::FlutterEngine,
+    desktop_window_state::InitData,
 };
 
 use log::error;
 
 pub struct JsonMethodChannel {
     name: String,
-    engine: Weak<FlutterEngine>,
+    init_data: Weak<InitData>,
     method_handler: Weak<RwLock<MethodCallHandler>>,
     plugin_name: Option<&'static str>,
 }
@@ -20,7 +19,7 @@ impl JsonMethodChannel {
     pub fn new(name: &str, method_handler: Weak<RwLock<MethodCallHandler>>) -> Self {
         Self {
             name: name.to_owned(),
-            engine: Weak::new(),
+            init_data: Weak::new(),
             method_handler,
             plugin_name: None,
         }
@@ -36,17 +35,15 @@ impl Channel for JsonMethodChannel {
         &self.name
     }
 
-    fn engine(&self) -> Option<Arc<FlutterEngine>> {
-        self.engine.upgrade()
+    fn init_data(&self) -> Option<Arc<InitData>> {
+        self.init_data.upgrade()
     }
 
-    fn init(&mut self, runtime_data: Weak<RuntimeData>, plugin_name: &'static str) {
-        if self.engine.upgrade().is_some() {
+    fn init(&mut self, init_data: Weak<InitData>, plugin_name: &'static str) {
+        if self.init_data.upgrade().is_some() {
             error!("Channel {} was already initialized", self.name);
         }
-        if let Some(runtime_data) = runtime_data.upgrade() {
-            self.engine = Arc::downgrade(&runtime_data.engine);
-        }
+        self.init_data = init_data;
         self.plugin_name.replace(plugin_name);
     }
 

--- a/flutter-engine/src/channel/json_method_channel.rs
+++ b/flutter-engine/src/channel/json_method_channel.rs
@@ -12,12 +12,12 @@ use log::error;
 pub struct JsonMethodChannel {
     name: String,
     engine: Weak<FlutterEngine>,
-    method_handler: Weak<RwLock<MethodCallHandler + Send + Sync>>,
+    method_handler: Weak<RwLock<MethodCallHandler>>,
     plugin_name: Option<&'static str>,
 }
 
 impl JsonMethodChannel {
-    pub fn new(name: &str, method_handler: Weak<RwLock<MethodCallHandler + Send + Sync>>) -> Self {
+    pub fn new(name: &str, method_handler: Weak<RwLock<MethodCallHandler>>) -> Self {
         Self {
             name: name.to_owned(),
             engine: Weak::new(),
@@ -26,7 +26,7 @@ impl JsonMethodChannel {
         }
     }
 
-    pub fn set_handler(&mut self, method_handler: Weak<RwLock<MethodCallHandler + Send + Sync>>) {
+    pub fn set_handler(&mut self, method_handler: Weak<RwLock<MethodCallHandler>>) {
         self.method_handler = method_handler;
     }
 }
@@ -50,7 +50,7 @@ impl Channel for JsonMethodChannel {
         self.plugin_name.replace(plugin_name);
     }
 
-    fn method_handler(&self) -> Option<Arc<RwLock<MethodCallHandler + Send + Sync>>> {
+    fn method_handler(&self) -> Option<Arc<RwLock<MethodCallHandler>>> {
         self.method_handler.upgrade()
     }
 

--- a/flutter-engine/src/channel/registry.rs
+++ b/flutter-engine/src/channel/registry.rs
@@ -1,5 +1,5 @@
 use super::Channel;
-use crate::{desktop_window_state::RuntimeData, ffi::PlatformMessage};
+use crate::{desktop_window_state::InitData, ffi::PlatformMessage};
 
 use std::{
     collections::HashMap,
@@ -11,20 +11,20 @@ use log::{trace, warn};
 
 pub struct ChannelRegistry {
     channels: HashMap<String, Arc<dyn Channel>>,
-    runtime_data: Weak<RuntimeData>,
+    init_data: Weak<InitData>,
 }
 
 pub struct ChannelRegistrar<'a> {
     plugin_name: &'static str,
-    runtime_data: &'a Weak<RuntimeData>,
+    init_data: &'a Weak<InitData>,
     channels: &'a mut HashMap<String, Arc<dyn Channel>>,
 }
 
 impl ChannelRegistry {
-    pub fn new(runtime_data: Weak<RuntimeData>) -> Self {
+    pub fn new(init_data: Weak<InitData>) -> Self {
         Self {
             channels: HashMap::new(),
-            runtime_data,
+            init_data,
         }
     }
 
@@ -34,18 +34,16 @@ impl ChannelRegistry {
     {
         let mut registrar = ChannelRegistrar {
             plugin_name,
-            runtime_data: &self.runtime_data,
+            init_data: &self.init_data,
             channels: &mut self.channels,
         };
         f(&mut registrar);
     }
 
     pub fn handle(&mut self, mut message: PlatformMessage) {
-        let runtime_data = self.runtime_data.upgrade().unwrap();
-        let window = runtime_data.window();
         if let Some(channel) = self.channels.get(message.channel.deref()) {
             trace!("Processing message from channel: {}", message.channel);
-            channel.handle_method(&mut message, window);
+            channel.handle_method(&mut message);
         } else {
             warn!(
                 "No plugin registered to handle messages from channel: {}",
@@ -57,7 +55,9 @@ impl ChannelRegistry {
                 "No response for channel {}, sending default empty response",
                 message.channel
             );
-            runtime_data
+            self.init_data
+                .upgrade()
+                .unwrap()
                 .engine
                 .send_platform_message_response(handle, &[]);
         }
@@ -69,7 +69,7 @@ impl<'a> ChannelRegistrar<'a> {
     where
         C: Channel + 'static,
     {
-        channel.init(Weak::clone(&self.runtime_data), self.plugin_name);
+        channel.init(Weak::clone(&self.init_data), self.plugin_name);
         let name = channel.name().to_owned();
         let arc = Arc::new(channel);
         let weak = Arc::downgrade(&arc);

--- a/flutter-engine/src/channel/standard_method_channel.rs
+++ b/flutter-engine/src/channel/standard_method_channel.rs
@@ -9,29 +9,32 @@ use crate::{
 use log::error;
 
 pub struct StandardMethodChannel {
-    name: String,
+    name: &'static str,
     init_data: Weak<InitData>,
-    method_handler: Weak<RwLock<MethodCallHandler>>,
+    method_handler: Weak<RwLock<MethodCallHandler + Send + Sync>>,
     plugin_name: Option<&'static str>,
 }
 
 impl StandardMethodChannel {
-    pub fn new(name: &str, method_handler: Weak<RwLock<MethodCallHandler>>) -> Self {
+    pub fn new(
+        name: &'static str,
+        method_handler: Weak<RwLock<MethodCallHandler + Send + Sync>>,
+    ) -> Self {
         Self {
-            name: name.to_owned(),
+            name,
             init_data: Weak::new(),
             method_handler,
             plugin_name: None,
         }
     }
 
-    pub fn set_handler(&mut self, method_handler: Weak<RwLock<MethodCallHandler>>) {
+    pub fn set_handler(&mut self, method_handler: Weak<RwLock<MethodCallHandler + Send + Sync>>) {
         self.method_handler = method_handler;
     }
 }
 
 impl Channel for StandardMethodChannel {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         &self.name
     }
 
@@ -47,7 +50,7 @@ impl Channel for StandardMethodChannel {
         self.plugin_name.replace(plugin_name);
     }
 
-    fn method_handler(&self) -> Option<Arc<RwLock<MethodCallHandler>>> {
+    fn method_handler(&self) -> Option<Arc<RwLock<MethodCallHandler + Send + Sync>>> {
         self.method_handler.upgrade()
     }
 

--- a/flutter-engine/src/channel/standard_method_channel.rs
+++ b/flutter-engine/src/channel/standard_method_channel.rs
@@ -12,12 +12,12 @@ use log::error;
 pub struct StandardMethodChannel {
     name: String,
     engine: Weak<FlutterEngine>,
-    method_handler: Weak<RwLock<MethodCallHandler + Send + Sync>>,
+    method_handler: Weak<RwLock<MethodCallHandler>>,
     plugin_name: Option<&'static str>,
 }
 
 impl StandardMethodChannel {
-    pub fn new(name: &str, method_handler: Weak<RwLock<MethodCallHandler + Send + Sync>>) -> Self {
+    pub fn new(name: &str, method_handler: Weak<RwLock<MethodCallHandler>>) -> Self {
         Self {
             name: name.to_owned(),
             engine: Weak::new(),
@@ -26,7 +26,7 @@ impl StandardMethodChannel {
         }
     }
 
-    pub fn set_handler(&mut self, method_handler: Weak<RwLock<MethodCallHandler + Send + Sync>>) {
+    pub fn set_handler(&mut self, method_handler: Weak<RwLock<MethodCallHandler>>) {
         self.method_handler = method_handler;
     }
 }
@@ -50,7 +50,7 @@ impl Channel for StandardMethodChannel {
         self.plugin_name.replace(plugin_name);
     }
 
-    fn method_handler(&self) -> Option<Arc<RwLock<MethodCallHandler + Send + Sync>>> {
+    fn method_handler(&self) -> Option<Arc<RwLock<MethodCallHandler>>> {
         self.method_handler.upgrade()
     }
 

--- a/flutter-engine/src/channel/standard_method_channel.rs
+++ b/flutter-engine/src/channel/standard_method_channel.rs
@@ -3,15 +3,14 @@ use std::sync::{Arc, RwLock, Weak};
 use crate::{
     channel::{Channel, MethodCallHandler},
     codec::{standard_codec::CODEC, MethodCodec},
-    desktop_window_state::RuntimeData,
-    ffi::FlutterEngine,
+    desktop_window_state::InitData,
 };
 
 use log::error;
 
 pub struct StandardMethodChannel {
     name: String,
-    engine: Weak<FlutterEngine>,
+    init_data: Weak<InitData>,
     method_handler: Weak<RwLock<MethodCallHandler>>,
     plugin_name: Option<&'static str>,
 }
@@ -20,7 +19,7 @@ impl StandardMethodChannel {
     pub fn new(name: &str, method_handler: Weak<RwLock<MethodCallHandler>>) -> Self {
         Self {
             name: name.to_owned(),
-            engine: Weak::new(),
+            init_data: Weak::new(),
             method_handler,
             plugin_name: None,
         }
@@ -36,17 +35,15 @@ impl Channel for StandardMethodChannel {
         &self.name
     }
 
-    fn engine(&self) -> Option<Arc<FlutterEngine>> {
-        self.engine.upgrade()
+    fn init_data(&self) -> Option<Arc<InitData>> {
+        self.init_data.upgrade()
     }
 
-    fn init(&mut self, runtime_data: Weak<RuntimeData>, plugin_name: &'static str) {
-        if self.engine.upgrade().is_some() {
+    fn init(&mut self, init_data: Weak<InitData>, plugin_name: &'static str) {
+        if self.init_data.upgrade().is_some() {
             error!("Channel {} was already initialized", self.name);
         }
-        if let Some(runtime_data) = runtime_data.upgrade() {
-            self.engine = Arc::downgrade(&runtime_data.engine);
-        }
+        self.init_data = init_data;
         self.plugin_name.replace(plugin_name);
     }
 

--- a/flutter-engine/src/desktop_window_state.rs
+++ b/flutter-engine/src/desktop_window_state.rs
@@ -76,6 +76,23 @@ impl RuntimeData {
         }))?;
         Ok(())
     }
+
+    pub fn with_channel<F>(
+        &self,
+        channel_name: &'static str,
+        mut f: F,
+    ) -> Result<(), crate::error::MethodCallError>
+    where
+        F: FnMut(&Channel) + Send + 'static,
+    {
+        self.channel_sender.send((
+            channel_name,
+            Box::new(move |channel| {
+                f(channel);
+            }),
+        ))?;
+        Ok(())
+    }
 }
 
 impl DesktopWindowState {

--- a/flutter-engine/src/ffi.rs
+++ b/flutter-engine/src/ffi.rs
@@ -132,9 +132,6 @@ pub struct FlutterEngine {
     engine_ptr: flutter_engine_sys::FlutterEngine,
 }
 
-unsafe impl Send for FlutterEngine {}
-unsafe impl Sync for FlutterEngine {}
-
 impl FlutterEngine {
     pub fn new(engine_ptr: flutter_engine_sys::FlutterEngine) -> Option<Self> {
         if engine_ptr.is_null() {

--- a/flutter-engine/src/flutter_callbacks.rs
+++ b/flutter-engine/src/flutter_callbacks.rs
@@ -7,7 +7,7 @@ use log::trace;
 pub extern "C" fn present(user_data: *mut c_void) -> bool {
     trace!("present");
     unsafe {
-        let user_data = &*(user_data as *mut DesktopUserData);
+        let user_data = &mut *(user_data as *mut DesktopUserData);
         if let Some(window) = user_data.get_window() {
             window.swap_buffers();
             true
@@ -20,7 +20,7 @@ pub extern "C" fn present(user_data: *mut c_void) -> bool {
 pub extern "C" fn make_current(user_data: *mut c_void) -> bool {
     trace!("make_current");
     unsafe {
-        let user_data = &*(user_data as *mut DesktopUserData);
+        let user_data = &mut *(user_data as *mut DesktopUserData);
         if let Some(window) = user_data.get_window() {
             window.make_current();
             true
@@ -49,7 +49,7 @@ pub extern "C" fn make_resource_current(_user_data: *mut c_void) -> bool {
 pub extern "C" fn gl_proc_resolver(user_data: *mut c_void, proc: *const c_char) -> *mut c_void {
     trace!("gl_proc_resolver");
     unsafe {
-        let user_data = &*(user_data as *mut DesktopUserData);
+        let user_data = &mut *(user_data as *mut DesktopUserData);
         if let Some(window) = user_data.get_window() {
             window
                 .glfw

--- a/flutter-engine/src/lib.rs
+++ b/flutter-engine/src/lib.rs
@@ -10,13 +10,15 @@ mod flutter_callbacks;
 pub mod plugins;
 mod utils;
 
-pub use crate::desktop_window_state::{DesktopWindowState, InitData, MainThreadFn, RuntimeData};
+pub use crate::desktop_window_state::{
+    ChannelFn, DesktopWindowState, InitData, MainThreadFn, RuntimeData,
+};
 use crate::ffi::FlutterEngine;
 pub use crate::ffi::PlatformMessage;
 
 use std::ffi::CString;
+use tokio::prelude::Future;
 
-use crate::desktop_window_state::ChannelFn;
 pub use glfw::Window;
 use log::error;
 
@@ -267,6 +269,7 @@ impl FlutterDesktop {
             }
 
             window_state.init_data.engine.shutdown();
+            window_state.runtime.shutdown_now().wait().unwrap();
         }
     }
 }

--- a/flutter-engine/src/lib.rs
+++ b/flutter-engine/src/lib.rs
@@ -16,6 +16,7 @@ pub use crate::ffi::PlatformMessage;
 
 use std::ffi::CString;
 
+use crate::desktop_window_state::ChannelFn;
 pub use glfw::Window;
 use log::error;
 
@@ -248,6 +249,16 @@ impl FlutterDesktop {
                 let window = window_state.window();
                 for mut f in fns {
                     f(window);
+                }
+
+                let fns: Vec<ChannelFn> = window_state.channel_receiver.try_iter().collect();
+                for mut f in fns {
+                    window_state
+                        .plugin_registrar
+                        .channel_registry
+                        .with_channel(f.0, |channel| {
+                            f.1(channel);
+                        });
                 }
 
                 unsafe {

--- a/flutter-engine/src/plugins.rs
+++ b/flutter-engine/src/plugins.rs
@@ -50,7 +50,7 @@ impl PluginRegistrar {
             let mut plugin = arc.write().unwrap();
             self.channel_registry
                 .with_channel_registrar(P::plugin_name(), |registrar| {
-                    plugin.init_channels(Arc::downgrade(&arc), registrar);
+                    plugin.init_channels(registrar);
                 });
         }
         self.plugins.insert(P::plugin_name().to_owned(), arc);
@@ -88,5 +88,5 @@ impl PluginRegistrar {
 
 pub trait Plugin {
     fn plugin_name() -> &'static str;
-    fn init_channels(&mut self, plugin: Weak<RwLock<Self>>, registrar: &mut ChannelRegistrar);
+    fn init_channels(&mut self, registrar: &mut ChannelRegistrar);
 }

--- a/flutter-engine/src/plugins.rs
+++ b/flutter-engine/src/plugins.rs
@@ -24,7 +24,7 @@ use std::{
 
 pub struct PluginRegistrar {
     plugins: HashMap<String, Arc<RwLock<dyn Any>>>,
-    channel_registry: ChannelRegistry,
+    pub channel_registry: ChannelRegistry,
 }
 
 impl PluginRegistrar {

--- a/flutter-engine/src/plugins.rs
+++ b/flutter-engine/src/plugins.rs
@@ -11,7 +11,7 @@ pub use self::{
 
 use crate::{
     channel::{ChannelRegistrar, ChannelRegistry},
-    desktop_window_state::RuntimeData,
+    desktop_window_state::InitData,
     ffi::PlatformMessage,
 };
 
@@ -28,10 +28,10 @@ pub struct PluginRegistrar {
 }
 
 impl PluginRegistrar {
-    pub fn new(runtime_data: Weak<RuntimeData>) -> Self {
+    pub fn new(init_data: Weak<InitData>) -> Self {
         Self {
             plugins: HashMap::new(),
-            channel_registry: ChannelRegistry::new(runtime_data),
+            channel_registry: ChannelRegistry::new(init_data),
         }
     }
 

--- a/flutter-engine/src/plugins/navigation.rs
+++ b/flutter-engine/src/plugins/navigation.rs
@@ -18,7 +18,7 @@ impl Plugin for NavigationPlugin {
         PLUGIN_NAME
     }
 
-    fn init_channels(&mut self, plugin: Weak<RwLock<Self>>, registrar: &mut ChannelRegistrar) {
+    fn init_channels(&mut self, registrar: &mut ChannelRegistrar) {
         let method_handler = Arc::downgrade(&self.handler);
         self.channel =
             registrar.register_channel(JsonMethodChannel::new(CHANNEL_NAME, method_handler));

--- a/flutter-engine/src/plugins/navigation.rs
+++ b/flutter-engine/src/plugins/navigation.rs
@@ -72,7 +72,7 @@ impl MethodCallHandler for NavigationPlugin {
         &mut self,
         _: &str,
         call: MethodCall,
-        _: &mut Window,
+        _: Arc<RuntimeData>,
     ) -> Result<Value, MethodCallError> {
         info!(
             "navigation method {:?} called with args {:?}",

--- a/flutter-engine/src/plugins/platform.rs
+++ b/flutter-engine/src/plugins/platform.rs
@@ -27,7 +27,7 @@ impl Plugin for PlatformPlugin {
         PLUGIN_NAME
     }
 
-    fn init_channels(&mut self, plugin: Weak<RwLock<Self>>, registrar: &mut ChannelRegistrar) {
+    fn init_channels(&mut self, registrar: &mut ChannelRegistrar) {
         let method_handler = Arc::downgrade(&self.handler);
         self.channel =
             registrar.register_channel(JsonMethodChannel::new(CHANNEL_NAME, method_handler));

--- a/flutter-engine/src/plugins/prelude.rs
+++ b/flutter-engine/src/plugins/prelude.rs
@@ -8,12 +8,12 @@ pub use crate::{
     ffi::PlatformMessageResponseHandle,
     json_value,
     plugins::{Plugin, PluginRegistrar},
-    Window,
+    MainThreadFn, RuntimeData, Window,
 };
 
 pub use std::{
     convert::{TryFrom, TryInto},
-    sync::{RwLock, Weak},
+    sync::{mpsc::Sender, Arc, RwLock, Weak},
 };
 
 pub use serde::{Deserialize, Serialize};

--- a/flutter-engine/src/plugins/textinput.rs
+++ b/flutter-engine/src/plugins/textinput.rs
@@ -76,7 +76,7 @@ impl MethodCallHandler for TextInputPlugin {
         &mut self,
         _: &str,
         call: MethodCall,
-        _: &mut Window,
+        _: Arc<RuntimeData>,
     ) -> Result<Value, MethodCallError> {
         match call.method.as_str() {
             "TextInput.setClient" => {

--- a/flutter-engine/src/plugins/textinput.rs
+++ b/flutter-engine/src/plugins/textinput.rs
@@ -29,7 +29,7 @@ impl Plugin for TextInputPlugin {
         PLUGIN_NAME
     }
 
-    fn init_channels(&mut self, plugin: Weak<RwLock<Self>>, registrar: &mut ChannelRegistrar) {
+    fn init_channels(&mut self, registrar: &mut ChannelRegistrar) {
         let method_handler = Arc::downgrade(&self.handler);
         self.channel =
             registrar.register_channel(JsonMethodChannel::new(CHANNEL_NAME, method_handler));

--- a/flutter-engine/src/utils.rs
+++ b/flutter-engine/src/utils.rs
@@ -107,6 +107,19 @@ impl OwnedStringUtils for String {
     }
 }
 
+/// This is a hacky trait to easier get a ref from the window pointer in [`DesktopWindowState`]. This
+/// trait allows getting a reference without borrowing the entire state, only the window pointer has
+/// to be borrowed mutably.
+pub(crate) trait WindowUnwrap {
+    fn window(&mut self) -> &mut glfw::Window;
+}
+
+impl WindowUnwrap for *mut glfw::Window {
+    fn window(&mut self) -> &mut glfw::Window {
+        unsafe { &mut **self }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
These changes make all method call handlers run in a background thread provided by tokio. All responses are now queued and sent on the main thread instead of allowing plugins to send responses on other threads.