### PR TITLE
Silence warning for unknown channel in plugin registrar

### DIFF
--- a/flutter-engine/src/flutter_callbacks.rs
+++ b/flutter-engine/src/flutter_callbacks.rs
@@ -1,9 +1,10 @@
 use super::DesktopUserData;
 
+use crate::ffi::PlatformMessage;
+
 use glfw::Context;
 use libc::{c_char, c_uint, c_void};
 use log::trace;
-use crate::ffi::PlatformMessage;
 
 pub extern "C" fn present(user_data: *mut c_void) -> bool {
     trace!("present");
@@ -69,16 +70,13 @@ pub extern "C" fn platform_message_callback(
     unsafe {
         let user_data = &mut *(user_data as *mut DesktopUserData);
         if let DesktopUserData::WindowState(window_state) = user_data {
-
             let msg: PlatformMessage = (*platform_message).into();
             if msg.channel == "flutter/isolate" {
                 // Special msg to signal isolate is setup
                 window_state.set_isolate_created();
+            } else {
+                window_state.plugin_registrar.handle(msg);
             }
-
-            window_state
-                .plugin_registrar
-                .handle(msg);
         }
     }
 }


### PR DESCRIPTION
This PR changes the platform callback to ensure that messages on the `flutter/isolate` channel aren't handled by the plugin registrar. That way, no warning is logged that no plugin is registered to handle messages on that channel.