### PR TITLE
fixed wrong key event direction

### DIFF
--- a/flutter-engine/src/desktop_window_state.rs
+++ b/flutter-engine/src/desktop_window_state.rs
@@ -501,14 +501,14 @@ impl DesktopWindowState {
 
                 self.plugin_registrar.with_plugin_mut(
                     |keyevent: &mut crate::plugins::KeyEventPlugin| {
-                        keyevent.key_action(true, key, scancode, modifiers);
+                        keyevent.key_action(false, key, scancode, modifiers);
                     },
                 );
             }
             glfw::WindowEvent::Key(key, scancode, glfw::Action::Release, modifiers) => {
                 self.plugin_registrar.with_plugin_mut(
                     |keyevent: &mut crate::plugins::KeyEventPlugin| {
-                        keyevent.key_action(false, key, scancode, modifiers);
+                        keyevent.key_action(true, key, scancode, modifiers);
                     },
                 );
             }

--- a/flutter-engine/src/plugins/keyevent.rs
+++ b/flutter-engine/src/plugins/keyevent.rs
@@ -46,18 +46,24 @@ impl KeyEventPlugin {
         }
     }
 
-    pub fn key_action(&self, down: bool, key: glfw::Key, scancode: glfw::Scancode, modifiers: glfw::Modifiers) {
+    pub fn key_action(
+        &self,
+        up: bool,
+        key: glfw::Key,
+        scancode: glfw::Scancode,
+        modifiers: glfw::Modifiers,
+    ) {
         self.with_channel(|channel| {
             let json = json_value!({
                 "toolkit": "glfw",
                 "keyCode": key as i32,
                 "scanCode": scancode as i32,
-                // "codePoint": 
+                // "codePoint":
                 "modifiers": modifiers.bits() as i32,
                 // TODO: raw_keyboard_listener.dart seems to have limited support for keyboard
                 // need to update later
                 "keymap": "linux",
-                "type": if down { "keyup" } else { "keydown" }
+                "type": if up { "keyup" } else { "keydown" }
             });
             channel.send(&json);
         });


### PR DESCRIPTION
Small fix for wrong key event direction assignment, which caused malfunction of flutter's ShorcutManager. 